### PR TITLE
Annotate pure calls with a babebl plugin, use tslib

### DIFF
--- a/dist/style-value-types.es.js
+++ b/dist/style-value-types.es.js
@@ -1,72 +1,81 @@
-/*! *****************************************************************************
-Copyright (c) Microsoft Corporation. All rights reserved.
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License. You may obtain a copy of the
-License at http://www.apache.org/licenses/LICENSE-2.0
+import { __assign } from 'tslib';
 
-THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-MERCHANTABLITY OR NON-INFRINGEMENT.
-
-See the Apache Version 2.0 License for specific language governing permissions
-and limitations under the License.
-***************************************************************************** */
-
-var __assign = Object.assign || function __assign(t) {
-    for (var s, i = 1, n = arguments.length; i < n; i++) {
-        s = arguments[i];
-        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
-    }
-    return t;
+var clamp = function (min, max) {
+    return function (v) {
+        return Math.max(Math.min(v, max), min);
+    };
 };
-
-var clamp = function (min, max) { return function (v) { return Math.max(Math.min(v, max), min); }; };
-var contains = function (term) { return function (v) { return (typeof v === 'string' && v.indexOf(term) !== -1); }; };
-var createUnitType = function (unit) { return ({
-    test: contains(unit),
-    parse: parseFloat,
-    transform: function (v) { return "" + v + unit; }
-}); };
-var isFirstChars = function (term) { return function (v) { return (typeof v === 'string' && v.indexOf(term) === 0); }; };
-var getValueFromFunctionString = function (value) { return value.substring(value.indexOf('(') + 1, value.lastIndexOf(')')); };
-var splitCommaDelimited = function (value) { return typeof value === 'string' ? value.split(/,\s*/) : [value]; };
+var contains = function (term) {
+    return function (v) {
+        return typeof v === 'string' && v.indexOf(term) !== -1;
+    };
+};
+var createUnitType = function (unit) {
+    return {
+        test: contains(unit),
+        parse: parseFloat,
+        transform: function (v) {
+            return "" + v + unit;
+        }
+    };
+};
+var isFirstChars = function (term) {
+    return function (v) {
+        return typeof v === 'string' && v.indexOf(term) === 0;
+    };
+};
+var getValueFromFunctionString = function (value) {
+    return value.substring(value.indexOf('(') + 1, value.lastIndexOf(')'));
+};
+var splitCommaDelimited = function (value) {
+    return typeof value === 'string' ? value.split(/,\s*/) : [value];
+};
 function splitColorValues(terms) {
     var numTerms = terms.length;
     return function (v) {
         var values = {};
         var valuesArray = splitCommaDelimited(getValueFromFunctionString(v));
         for (var i = 0; i < numTerms; i++) {
-            values[terms[i]] = (valuesArray[i] !== undefined) ? parseFloat(valuesArray[i]) : 1;
+            values[terms[i]] = valuesArray[i] !== undefined ? parseFloat(valuesArray[i]) : 1;
         }
         return values;
     };
 }
 var number = {
-    test: function (v) { return typeof v === 'number'; },
+    test: function (v) {
+        return typeof v === 'number';
+    },
     parse: parseFloat,
-    transform: function (v) { return v; }
+    transform: function (v) {
+        return v;
+    }
 };
-var alpha = __assign({}, number, { transform: clamp(0, 1) });
-var degrees = createUnitType('deg');
-var percent = createUnitType('%');
-var px = createUnitType('px');
-var scale = __assign({}, number, { default: 1 });
+var alpha = /*#__PURE__*/__assign({}, number, { transform: /*#__PURE__*/clamp(0, 1) });
+var degrees = /*#__PURE__*/createUnitType('deg');
+var percent = /*#__PURE__*/createUnitType('%');
+var px = /*#__PURE__*/createUnitType('px');
+var scale = /*#__PURE__*/__assign({}, number, { default: 1 });
 var FLOAT_REGEX = /(-)?(\d[\d\.]*)/g;
-var generateToken = function (token) { return '${' + token + '}'; };
+var generateToken = function (token) {
+    return '${' + token + '}';
+};
 var complex = {
     test: function (v) {
         var matches = v.match && v.match(FLOAT_REGEX);
-        return (matches !== undefined && matches.constructor === Array && matches.length > 1);
+        return matches !== undefined && matches.constructor === Array && matches.length > 1;
     },
     parse: function (v) {
         var parsedValue = {};
-        v.match(FLOAT_REGEX).forEach(function (value, i) { return parsedValue[i] = parseFloat(value); });
+        v.match(FLOAT_REGEX).forEach(function (value, i) {
+            return parsedValue[i] = parseFloat(value);
+        });
         return parsedValue;
     },
     createTransformer: function (prop) {
         var counter = 0;
-        var template = prop.replace(FLOAT_REGEX, function () { return generateToken("" + counter++); });
+        var template = prop.replace(FLOAT_REGEX, function () {
+            return generateToken("" + counter++);
+        });
         return function (v) {
             var output = template;
             for (var key in v) {
@@ -78,17 +87,26 @@ var complex = {
         };
     }
 };
-var clampRgbUnit = clamp(0, 255);
-var rgbUnit = __assign({}, number, { transform: function (v) { return Math.round(clampRgbUnit(v)); } });
+var clampRgbUnit = /*#__PURE__*/clamp(0, 255);
+var rgbUnit = /*#__PURE__*/__assign({}, number, { transform: function (v) {
+        return Math.round(clampRgbUnit(v));
+    } });
 var rgbaTemplate = function (_a) {
-    var red = _a.red, green = _a.green, blue = _a.blue, _b = _a.alpha, alpha = _b === void 0 ? 1 : _b;
+    var red = _a.red,
+        green = _a.green,
+        blue = _a.blue,
+        _b = _a.alpha,
+        alpha = _b === void 0 ? 1 : _b;
     return "rgba(" + red + ", " + green + ", " + blue + ", " + alpha + ")";
 };
 var rgba = {
-    test: isFirstChars('rgb'),
-    parse: splitColorValues(['red', 'green', 'blue', 'alpha']),
+    test: /*#__PURE__*/isFirstChars('rgb'),
+    parse: /*#__PURE__*/splitColorValues(['red', 'green', 'blue', 'alpha']),
     transform: function (_a) {
-        var red = _a.red, green = _a.green, blue = _a.blue, alpha = _a.alpha;
+        var red = _a.red,
+            green = _a.green,
+            blue = _a.blue,
+            alpha = _a.alpha;
         return rgbaTemplate({
             red: rgbUnit.transform(red),
             green: rgbUnit.transform(green),
@@ -98,14 +116,21 @@ var rgba = {
     }
 };
 var hslaTemplate = function (_a) {
-    var hue = _a.hue, saturation = _a.saturation, lightness = _a.lightness, _b = _a.alpha, alpha = _b === void 0 ? 1 : _b;
+    var hue = _a.hue,
+        saturation = _a.saturation,
+        lightness = _a.lightness,
+        _b = _a.alpha,
+        alpha = _b === void 0 ? 1 : _b;
     return "hsla(" + hue + ", " + saturation + ", " + lightness + ", " + alpha + ")";
 };
 var hsla = {
-    test: isFirstChars('hsl'),
-    parse: splitColorValues(['hue', 'saturation', 'lightness', 'alpha']),
+    test: /*#__PURE__*/isFirstChars('hsl'),
+    parse: /*#__PURE__*/splitColorValues(['hue', 'saturation', 'lightness', 'alpha']),
     transform: function (_a) {
-        var hue = _a.hue, saturation = _a.saturation, lightness = _a.lightness, alpha = _a.alpha;
+        var hue = _a.hue,
+            saturation = _a.saturation,
+            lightness = _a.lightness,
+            alpha = _a.alpha;
         return hslaTemplate({
             hue: Math.round(hue),
             saturation: percent.transform(saturation),
@@ -114,14 +139,13 @@ var hsla = {
         });
     }
 };
-var hex = __assign({}, rgba, { test: isFirstChars('#'), parse: function (v) {
+var hex = /*#__PURE__*/__assign({}, rgba, { test: /*#__PURE__*/isFirstChars('#'), parse: function (v) {
         var r, g, b;
         if (v.length > 4) {
             r = v.substr(1, 2);
             g = v.substr(3, 2);
             b = v.substr(5, 2);
-        }
-        else {
+        } else {
             r = v.substr(1, 1);
             g = v.substr(2, 1);
             b = v.substr(3, 1);
@@ -136,18 +160,22 @@ var hex = __assign({}, rgba, { test: isFirstChars('#'), parse: function (v) {
             alpha: 1
         };
     } });
-var isRgba = function (v) { return v.red !== undefined; };
-var isHsla = function (v) { return v.hue !== undefined; };
+var isRgba = function (v) {
+    return v.red !== undefined;
+};
+var isHsla = function (v) {
+    return v.hue !== undefined;
+};
 var color = {
-    test: function (v) { return rgba.test(v) || hsla.test(v) || hex.test(v); },
+    test: function (v) {
+        return rgba.test(v) || hsla.test(v) || hex.test(v);
+    },
     parse: function (v) {
         if (rgba.test(v)) {
             return rgba.parse(v);
-        }
-        else if (hsla.test(v)) {
+        } else if (hsla.test(v)) {
             return hsla.parse(v);
-        }
-        else if (hex.test(v)) {
+        } else if (hex.test(v)) {
             return hex.parse(v);
         }
         return v;
@@ -155,12 +183,11 @@ var color = {
     transform: function (v) {
         if (isRgba(v)) {
             return rgba.transform(v);
-        }
-        else if (isHsla(v)) {
+        } else if (isHsla(v)) {
             return hsla.transform(v);
         }
         return v;
-    },
+    }
 };
 
 export { getValueFromFunctionString, splitCommaDelimited, splitColorValues, number, alpha, degrees, percent, px, scale, complex, rgbUnit, rgba, hsla, hex, color };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,21 @@
 {
   "name": "style-value-types",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.1.tgz",
+      "integrity": "sha512-n7wxy8r2tjVcrzZoKJlyZmi1C1VhXGHAGhDEO1iqp7fbsTSsDF3dVA50KFsPg77EXqzNJqbzcna8Mi4m7a1lyw==",
+      "dev": true
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -213,6 +225,29 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
+    "babel-cli": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.13.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -225,9 +260,9 @@
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -240,15 +275,23 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
+        "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -283,7 +326,7 @@
       "integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-plugin-istanbul": "4.1.5",
         "babel-preset-jest": "20.0.3"
       }
@@ -295,6 +338,15 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-annotate-pure-calls": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz",
+      "integrity": "sha512-0IP5H7eRCKPKcas8JCJf11c6OrSNmYmc3Ehaz+JFLasa4a2pLvfnfOeMBYMdqmutXjXcoqWA+H7ZyzHo008S/w==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "6.18.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -312,6 +364,12 @@
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
       "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
       "dev": true
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -336,6 +394,25 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-jest": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
@@ -351,7 +428,7 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
         "core-js": "2.5.1",
         "home-or-tmp": "2.0.0",
@@ -1395,6 +1472,12 @@
         "jsonfile": "4.0.0",
         "universalify": "0.1.1"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2512,6 +2595,40 @@
           "requires": {
             "amdefine": "1.0.1"
           }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -3158,7 +3275,7 @@
       "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-jest": "20.0.3",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "1.1.3",
@@ -3809,6 +3926,17 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -4006,9 +4134,9 @@
       }
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process": {
@@ -4312,6 +4440,16 @@
         "inherits": "2.0.3"
       }
     },
+    "rollup": {
+      "version": "0.59.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.59.1.tgz",
+      "integrity": "sha512-Zozx6Vq1ieUpl53mi8N7nvJD7yl4Kf4QUiuIjN/e8Fj54HxBmIeRDX1IawDO82N7NWKo4KaKoL3JOfXTtO9C2Q==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "10.1.1"
+      }
+    },
     "rollup-plugin-typescript2": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.14.0.tgz",
@@ -4321,7 +4459,7 @@
         "fs-extra": "5.0.0",
         "resolve": "1.7.1",
         "rollup-pluginutils": "2.2.0",
-        "tslib": "1.9.0"
+        "tslib": "1.9.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -4749,7 +4887,7 @@
       "integrity": "sha1-noITDOprbfcYssK2BVRSr0a7JI0=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-plugin-istanbul": "4.1.5",
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-preset-jest": "20.0.3",
@@ -4922,10 +5060,9 @@
       }
     },
     "tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-      "dev": true
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+      "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -4965,27 +5102,26 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.3.25",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.25.tgz",
+      "integrity": "sha512-hobogryjDV36VrLK3Y69ou4REyrTApzUblVFmdQOYRe8cYaSmFJXMb4dR9McdvYDSbeNdzUgYr2YVukJaErJcA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "commander": "2.15.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -5005,6 +5141,31 @@
         "source-map": "0.5.7",
         "uglify-js": "2.8.29",
         "webpack-sources": "1.0.1"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          }
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
       }
     },
     "universalify": {
@@ -5030,6 +5191,12 @@
           "dev": true
         }
       }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
     },
     "util": {
       "version": "0.10.3",
@@ -5059,6 +5226,15 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "postbuild": "babel $npm_package_module --out-file $npm_package_module --no-babelrc --plugins annotate-pure-calls",
     "watch": "rollup -c -w",
     "lint": "tslint -c tslint.json 'src/**/*.{ts}'",
     "test": "jest",
-    "measure": "gzip -c dist/style-value-types.min.js | wc -c",
+    "measure": "uglifyjs $npm_package_main -cm --toplevel | gzip -c | wc -c",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "repository": {
@@ -36,11 +37,16 @@
   },
   "homepage": "https://github.com/Popmotion/style-value-types#readme",
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "jest": "^20.0.4",
+    "rollup": "^0.59.1",
     "rollup-plugin-typescript2": "^0.14.0",
     "rollup-plugin-uglify": "^3.0.0",
     "ts-jest": "^20.0.10",
     "typescript": "^2.4.2",
+    "uglify-js": "^3.3.25",
     "webpack": "^3.0.0"
   },
   "jest": {
@@ -58,5 +64,8 @@
   "prettier": {
     "parser": "typescript",
     "singleQuote": true
+  },
+  "dependencies": {
+    "tslib": "^1.9.1"
   }
 }


### PR DESCRIPTION
Similar to the previous one.

Only size related change is using `tslib` instead of inline TS helpers - this removes `__assign` from the source.

It also includes auto `#__PURE__` comments for initialization calls which makes it possible for UglifyJS to drop those calls (and their deps) if call's result stay unused.